### PR TITLE
Use variables instead of map to prevent call mapaccess1_faststr

### DIFF
--- a/tick.go
+++ b/tick.go
@@ -124,12 +124,13 @@ func GeneratePrettyContinuousTicks(r Renderer, ra Range, isVertical bool, style 
 	}
 
 	prettyStepsPriorityList := []float64{1, 5, 2, 2.5, 4, 3}
-	paramWeights := map[string]float64{
-		"simplicity": 0.2,
-		"coverage":   0.25,
-		"density":    0.5,
-		"legibility": 0.05,
-	}
+
+	var (
+		simplicityParam = 0.2
+		coverageParam   = 0.25
+		densityParam    = 0.5
+		legibilityParam = 0.05
+	)
 
 	rangeMin, rangeMax := ra.GetMin(), ra.GetMax()
 
@@ -165,10 +166,10 @@ OUTER:
 		for prettyStepIndex, prettyStep := range prettyStepsPriorityList {
 			simplicityMax := calculateSimplicityMax(float64(prettyStepIndex), prettyStepsCount, stepsToSkip)
 
-			if paramWeights["simplicity"]*simplicityMax+
-				paramWeights["coverage"]+
-				paramWeights["density"]+
-				paramWeights["legibility"] < bestScore {
+			if simplicityParam*simplicityMax+
+				coverageParam+
+				densityParam+
+				legibilityParam < bestScore {
 				break OUTER
 			}
 
@@ -176,10 +177,10 @@ OUTER:
 			for {
 				densityMax := calculateDensityMax(ticksCount, desiredTicksCount)
 
-				if paramWeights["simplicity"]*simplicityMax+
-					paramWeights["coverage"]+
-					paramWeights["density"]*densityMax+
-					paramWeights["legibility"] < bestScore {
+				if simplicityParam*simplicityMax+
+					coverageParam+
+					densityParam*densityMax+
+					legibilityParam < bestScore {
 					break
 				}
 
@@ -190,10 +191,10 @@ OUTER:
 					tickStep := stepsToSkip * prettyStep * math.Pow(10, stepSizeMultiplierLog)
 					coverageMax := calculateCoverageMax(rangeMin, rangeMax, tickStep*(ticksCount-1))
 
-					if paramWeights["simplicity"]*simplicityMax+
-						paramWeights["coverage"]*coverageMax+
-						paramWeights["density"]*densityMax+
-						paramWeights["legibility"] < bestScore {
+					if simplicityParam*simplicityMax+
+						coverageParam*coverageMax+
+						densityParam*densityMax+
+						legibilityParam < bestScore {
 						break
 					}
 
@@ -219,10 +220,10 @@ OUTER:
 							legibility = math.Inf(-1) // overlap is unacceptable
 						}
 
-						score := paramWeights["simplicity"]*simplicity +
-							paramWeights["coverage"]*coverage +
-							paramWeights["density"]*density +
-							paramWeights["legibility"]*legibility
+						score := simplicityParam*simplicity +
+							coverageParam*coverage +
+							densityParam*density +
+							legibilityParam*legibility
 
 						// original algorithm allows ticks outside value range, but it breaks rendering in this library
 						if score > bestScore && tickMin >= rangeMin && tickMax <= rangeMax {

--- a/tick.go
+++ b/tick.go
@@ -125,7 +125,7 @@ func GeneratePrettyContinuousTicks(r Renderer, ra Range, isVertical bool, style 
 
 	prettyStepsPriorityList := []float64{1, 5, 2, 2.5, 4, 3}
 
-	var (
+	const (
 		simplicityParam = 0.2
 		coverageParam   = 0.25
 		densityParam    = 0.5

--- a/util/math_test.go
+++ b/util/math_test.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"math"
 	"testing"
 
 	"github.com/blend/go-sdk/assert"
@@ -152,5 +153,5 @@ func TestRotateCoordinate45(t *testing.T) {
 
 func TestSqrFloat(t *testing.T) {
 	assert := assert.New(t)
-	assert.True(math.Abs(4 - Math.SqrFloat(2)) < 1e-9)
+	assert.True(math.Abs(4-Math.SqrFloat(2)) < 1e-9)
 }


### PR DESCRIPTION
Change to use simple variable instead of map

### Why?
In profie we can see use a lot of CPU for access to map
For prevent it i remove map and rewrite it on variables.

### Benchmark
#### Before
```
goos: darwin
goarch: arm64
pkg: github.com/moira-alert/go-chart
BenchmarkGenerateContinuousTicks
BenchmarkGenerateContinuousTicks-8   	    3794	    303193 ns/op
PASS
```

#### After
```
goos: darwin
goarch: arm64
pkg: github.com/moira-alert/go-chart
BenchmarkGenerateContinuousTicks
BenchmarkGenerateContinuousTicks-8   	    4454	    250404 ns/op
PASS
```

### Profiling
#### Before
![image](https://user-images.githubusercontent.com/5462695/212134466-529d3a43-1a66-4e87-8d93-1be53122ccd9.png)

#### After
![image](https://user-images.githubusercontent.com/5462695/212134488-25e7b575-c6e6-432f-810a-56743d680ed6.png)
